### PR TITLE
Fix invalid example code in doc of blame_with_message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
+version = "0.37.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -2954,7 +2954,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
- "rustix 0.37.23",
+ "rustix 0.37.25",
  "windows-sys 0.48.0",
 ]
 

--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -910,7 +910,7 @@
             if value == 0 then
               value
             else
-              std.contract.blame_with_message_message "Not zero" label
+              std.contract.blame_with_message "Not zero" label
           in
 
           0 | IsZero


### PR DESCRIPTION
Fix wrong method name: "std.contract.blame_with_message_message"
should be: "std.contract.blame_with_message"