### PR TITLE
Bgni fix doc blame with message message old

### DIFF
--- a/core/stdlib/std.ncl
+++ b/core/stdlib/std.ncl
@@ -910,7 +910,7 @@
             if value == 0 then
               value
             else
-              std.contract.blame_with_message_message "Not zero" label
+              std.contract.blame_with_message "Not zero" label
           in
 
           0 | IsZero


### PR DESCRIPTION
Fix wrong method name: "std.contract.blame_with_message_message"
should be: "std.contract.blame_with_message"
